### PR TITLE
Words conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 
 - Converts LaTeX-like abbreviations into Unicode characters.
 
+### Distributor
+
+You can use a distributor to distribute a prefix to a sequence of characters.
+
+The default distributor character is `#` and can be changed with the `abbreviations.distributor` option. Set this option to the empty string `""` to disable.
+
+If the prefix is empty, the abbreviation is left unchanged. Eg. `\#foo` is *not* distributed to `\foo` and is rather directly converted to `♯foo`.
+
+Example: `\bf#Set` will be distributed to `\bfS\bfe\bft` and converted to 𝐒𝐞𝐭.
+
 ## Installation
 
 With `lazy.nvim`:

--- a/lua/tex2uni/abbreviations.lua
+++ b/lua/tex2uni/abbreviations.lua
@@ -177,7 +177,7 @@ local function insert_char_pre()
 	end
 end
 
-local function convert_abbrev(abbrev)
+local function convert_abbrev(abbrev, distribute)
 	if abbrev:find(abbreviations.leader) ~= 1 then
 		return abbrev
 	end
@@ -185,7 +185,10 @@ local function convert_abbrev(abbrev)
 	if abbrev:find(abbreviations.leader) == 1 then
 		return abbreviations.leader .. convert_abbrev(abbrev:sub(#abbreviations.leader + 1))
 	end
-	if abbreviations.distributor ~= "" then
+	if distribute == nil then
+		distribute = (abbreviations.distributor ~= "")
+	end
+	if distribute then
 		local distrpos = abbrev:find(abbreviations.distributor)
 		if distrpos ~= fail then
 			local prefix = abbrev:sub(1, distrpos - 1)
@@ -193,7 +196,7 @@ local function convert_abbrev(abbrev)
 			for i = distrpos + 1, #abbrev do
 				newabbrev = newabbrev .. abbreviations.leader .. prefix .. abbrev:sub(i,i)
 			end
-			return convert_abbrev(newabbrev)
+			return convert_abbrev(newabbrev, false)
 		end
 	end
 	local matchlen, fromlen, repl = 0, 99999, ""

--- a/lua/tex2uni/abbreviations.lua
+++ b/lua/tex2uni/abbreviations.lua
@@ -185,6 +185,15 @@ local function convert_abbrev(abbrev)
 	if abbrev:find(abbreviations.leader) == 1 then
 		return abbreviations.leader .. convert_abbrev(abbrev:sub(#abbreviations.leader + 1))
 	end
+	local distrpos = abbrev:find(abbreviations.distributor)
+	if distrpos ~= fail then
+		local prefix = abbrev:sub(1, distrpos - 1)
+		local newabbrev = ""
+		for i = distrpos + 1, #abbrev do
+			newabbrev = newabbrev .. abbreviations.leader .. prefix .. abbrev:sub(i,i)
+		end
+		return convert_abbrev(newabbrev)
+	end
 	local matchlen, fromlen, repl = 0, 99999, ""
 	for from, to in pairs(abbreviations.abbreviations) do
 		local curmatchlen = 0
@@ -239,9 +248,10 @@ function abbreviations.convert()
 end
 
 function abbreviations.enable(pattern, opts)
-	opts = vim.tbl_extend("keep", opts or {}, { leader = "\\", extra = {} })
+	opts = vim.tbl_extend("keep", opts or {}, { leader = "\\", distributor = "#", extra = {} })
 
 	abbreviations.leader = opts.leader
+	abbreviations.distributor = opts.distributor
 
 	abbreviations.abbreviations = abbreviations.load()
 	for from, to in pairs(opts.extra) do

--- a/lua/tex2uni/abbreviations.lua
+++ b/lua/tex2uni/abbreviations.lua
@@ -185,14 +185,16 @@ local function convert_abbrev(abbrev)
 	if abbrev:find(abbreviations.leader) == 1 then
 		return abbreviations.leader .. convert_abbrev(abbrev:sub(#abbreviations.leader + 1))
 	end
-	local distrpos = abbrev:find(abbreviations.distributor)
-	if distrpos ~= fail then
-		local prefix = abbrev:sub(1, distrpos - 1)
-		local newabbrev = ""
-		for i = distrpos + 1, #abbrev do
-			newabbrev = newabbrev .. abbreviations.leader .. prefix .. abbrev:sub(i,i)
+	if abbreviations.distributor ~= "" then
+		local distrpos = abbrev:find(abbreviations.distributor)
+		if distrpos ~= fail then
+			local prefix = abbrev:sub(1, distrpos - 1)
+			local newabbrev = ""
+			for i = distrpos + 1, #abbrev do
+				newabbrev = newabbrev .. abbreviations.leader .. prefix .. abbrev:sub(i,i)
+			end
+			return convert_abbrev(newabbrev)
 		end
-		return convert_abbrev(newabbrev)
 	end
 	local matchlen, fromlen, repl = 0, 99999, ""
 	for from, to in pairs(abbreviations.abbreviations) do

--- a/lua/tex2uni/abbreviations.lua
+++ b/lua/tex2uni/abbreviations.lua
@@ -183,14 +183,14 @@ local function convert_abbrev(abbrev, distribute)
 	end
 	abbrev = abbrev:sub(#abbreviations.leader + 1)
 	if abbrev:find(abbreviations.leader) == 1 then
-		return abbreviations.leader .. convert_abbrev(abbrev:sub(#abbreviations.leader + 1))
+		return abbreviations.leader .. convert_abbrev(abbrev:sub(#abbreviations.leader + 1), distribute)
 	end
 	if distribute == nil then
 		distribute = (abbreviations.distributor ~= "")
 	end
 	if distribute then
 		local distrpos = abbrev:find(abbreviations.distributor)
-		if distrpos ~= fail then
+		if distrpos ~= fail and distrpos ~= 1 then
 			local prefix = abbrev:sub(1, distrpos - 1)
 			local newabbrev = ""
 			for i = distrpos + 1, #abbrev do
@@ -216,7 +216,7 @@ local function convert_abbrev(abbrev, distribute)
 	if matchlen == 0 then
 		return abbreviations.leader .. abbrev
 	end
-	return repl .. convert_abbrev(abbrev:sub(matchlen + 1))
+	return repl .. convert_abbrev(abbrev:sub(matchlen + 1), distribute)
 end
 
 function abbreviations.convert()

--- a/lua/tex2uni/config.lua
+++ b/lua/tex2uni/config.lua
@@ -14,6 +14,7 @@
 ---@class tex2uni.abbreviations.Config
 ---@field enable? boolean whether to automatically enable expansion
 ---@field leader? string which key to use to trigger abbreviation expansion
+---@field distributor? string which key to use to distribute
 ---@field extra table<string, string> a table of extra abbreviations to enable
 
 ---@type tex2uni.MergedConfig
@@ -23,6 +24,7 @@ local DEFAULTS = {
 	---@type tex2uni.abbreviations.Config
 	abbreviations = {
 		leader = "\\",
+		distributor = "\#",
 		extra = {},
 	},
 


### PR DESCRIPTION
This pull request adds the possibility to write whole words in mathbb/mathbf for instance.

For this I introduce an new option `abbreviations.distributor` which is a character and defaults to `#`.  Now when I write `\bf#Set`, the prefix (before the distributor character) will be distributed to each letter of the postfix (after the distributor character). This will produce `\bfS\bfe\bft`, which will then be converted to 𝐒𝐞𝐭.

This can distribute any prefix. The distribution is not recursive (`\bf#a#b` is only distributed to `\bfa\bf#\bfb`). This can be disabled by setting the distributor character to "".

I think it is better to have a non empty default since users could get confused by choosing a distributor that will mess with the abbreviations (if it a character appearing in the middle on an abbreviation for instance).